### PR TITLE
FIX: Updated grep commands to use Variables

### DIFF
--- a/runas.sh
+++ b/runas.sh
@@ -42,9 +42,9 @@ function create_user {
   USER="user_${USER_ID}_$GROUP_ID"
   GROUP="group_${USER_ID}_$GROUP_ID"
 
-  if grep -q '^[^:]*:[^:]*:99:100:' /etc/passwd >/dev/null 2>&1
+  if grep -q "^[^:]*:[^:]*:$USER_ID:$GROUP_ID:" /etc/passwd >/dev/null 2>&1
   then
-    USER=$(grep '^[^:]*:[^:]*:99:100:' /etc/passwd | sed 's/:.*//')
+    USER=$(grep "^[^:]*:[^:]*:$USER_ID:$GROUP_ID:" /etc/passwd | sed 's/:.*//')
 
     if [[ $USER == *$'\n'* ]]
     then
@@ -56,9 +56,9 @@ function create_user {
     return
   fi
 
-  if grep -q '^[^:]*:[^:]*:99:' /etc/passwd >/dev/null 2>&1
+  if grep -q "^[^:]*:[^:]*:$USER_ID:" /etc/passwd >/dev/null 2>&1
   then
-    USER=$(grep '^[^:]*:[^:]*:99:100:' /etc/passwd | sed 's/:.*//')
+    USER=$(grep "^[^:]*:[^:]*:$USER_ID:" /etc/passwd | sed 's/:.*//')
 
     if [[ $USER == *$'\n'* ]]
     then


### PR DESCRIPTION
Replace Hard coded UID (99) and GID (100) in grep commands with the Variables $USER_ID and $GROUP_ID that it is suppose to be using.